### PR TITLE
Achievements Admin Page With Thumbnails

### DIFF
--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -345,3 +345,75 @@ function dpa_achievement_index_contextual_help() {
 		'<p><a href="http://wordpress.org/support/plugin/achievements/" target="_blank">' . __( 'Support Forums', 'dpa' ) . '</a></p>'
 	);
 }
+
+/**
+ * Set thumbnail size for achievements in admin page.
+ *
+ * @since Achievements (3.2.2)
+ * @author Mike Bronner <mike.bronner@gmail.com>
+ */
+add_image_size('achievement-admin-list-thumb', 50, 50, false);
+	
+
+/**
+ * Configures the column order and headers.
+ *
+ * @param array $columns
+ * @since Achievements (3.2.2)
+ * @author Mike Bronner <mike.bronner@gmail.com>
+ */
+ function achievements_admin_thumbnail($columns)
+{
+	$column_position = 2; //choose what position you want the categories to be added
+	$columns_first = array_slice($columns, 0, $column_position - 1, true );
+	$columns_last = array_slice($columns, $column_position - 1, null, true );
+	$columns = array_merge
+	(
+		$columns_first,
+		array('dpa_achievement_thumb' => __('Featured')),
+		$columns_last
+	);
+
+	return $columns;
+}
+
+/**
+ * Register filter for function achievements_admin_thumbnail().
+ *
+ * @since Achievements (3.2.2)
+ * @author Mike Bronner <mike.bronner@gmail.com>
+ */
+add_filter('manage_edit-achievement_columns', 'achievements_admin_thumbnail');
+	
+/**
+ * Handles the content of the thumbnail column.
+ *
+ * @param array $column
+ * @param int $id
+ * @since Achievements (3.2.2)
+ * @author Mike Bronner <mike.bronner@gmail.com>
+ */
+function dpa_achievement_admin_thumbnail_column($column, $id)
+{
+	switch ($column)
+	{
+		case 'dpa_achievement_thumb':
+			if (function_exists('the_post_thumbnail'))
+			{
+				echo the_post_thumbnail( 'achievement-admin-list-thumb' );
+			}
+			else
+			{
+				echo "Thumbnails not supported.";
+			}
+		break;
+	}
+}
+
+/**
+ * Register action for function dpa_achievement_admin_thumbnail_column().
+ *
+ * @since Achievements (3.2.2)
+ * @author Mike Bronner <mike.bronner@gmail.com>
+ */
+add_action('manage_posts_custom_column', 'achievement_admin_thumbnail_column', 5, 2);

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -370,7 +370,7 @@ add_image_size('dpa-achievement-admin-list-thumb', 50, 50, false);
 	$columns = array_merge
 	(
 		$columns_first,
-		array('dpa_achievement_thumb' => __('Featured')),
+		array('dpa_achievement_thumb' => __('Badge')),
 		$columns_last
 	);
 

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -364,13 +364,13 @@ add_image_size('dpa-achievement-admin-list-thumb', 50, 50, false);
  */
  function dpa_achievements_admin_thumbnail($columns)
 {
-	$column_position = 2; //choose what position you want the categories to be added
+	$column_position = 2; //choose what position you want the categories to be added.
 	$columns_first = array_slice($columns, 0, $column_position - 1, true );
 	$columns_last = array_slice($columns, $column_position - 1, null, true );
 	$columns = array_merge
 	(
 		$columns_first,
-		array('dpa_achievement_thumb' => __('Badge')),
+		array('dpa_achievement_thumb' => __('Badge')), //change this to whatever you want to title the column.
 		$columns_last
 	);
 

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -352,8 +352,8 @@ function dpa_achievement_index_contextual_help() {
  * @since Achievements (3.2.2)
  * @author Mike Bronner <mike.bronner@gmail.com>
  */
-add_image_size('achievement-admin-list-thumb', 50, 50, false);
-	
+add_image_size('dpa-achievement-admin-list-thumb', 50, 50, false);
+
 
 /**
  * Configures the column order and headers.
@@ -362,7 +362,7 @@ add_image_size('achievement-admin-list-thumb', 50, 50, false);
  * @since Achievements (3.2.2)
  * @author Mike Bronner <mike.bronner@gmail.com>
  */
- function achievements_admin_thumbnail($columns)
+ function dpa_achievements_admin_thumbnail($columns)
 {
 	$column_position = 2; //choose what position you want the categories to be added
 	$columns_first = array_slice($columns, 0, $column_position - 1, true );
@@ -383,8 +383,8 @@ add_image_size('achievement-admin-list-thumb', 50, 50, false);
  * @since Achievements (3.2.2)
  * @author Mike Bronner <mike.bronner@gmail.com>
  */
-add_filter('manage_edit-achievement_columns', 'achievements_admin_thumbnail');
-	
+add_filter('manage_edit-achievement_columns', 'dpa_achievements_admin_thumbnail');
+
 /**
  * Handles the content of the thumbnail column.
  *
@@ -400,7 +400,7 @@ function dpa_achievement_admin_thumbnail_column($column, $id)
 		case 'dpa_achievement_thumb':
 			if (function_exists('the_post_thumbnail'))
 			{
-				echo the_post_thumbnail( 'achievement-admin-list-thumb' );
+				echo the_post_thumbnail( 'dpa-achievement-admin-list-thumb' );
 			}
 			else
 			{
@@ -416,4 +416,4 @@ function dpa_achievement_admin_thumbnail_column($column, $id)
  * @since Achievements (3.2.2)
  * @author Mike Bronner <mike.bronner@gmail.com>
  */
-add_action('manage_posts_custom_column', 'achievement_admin_thumbnail_column', 5, 2);
+add_action('manage_posts_custom_column', 'dpa_achievement_admin_thumbnail_column', 5, 2);


### PR DESCRIPTION
I have added the code necessary to show thumbnails in the admin page. Below is a preview of what it might look like. Disregard the Category columns as that is not part of this functionality.

The thumbnail header is not sortable at this time -- I didn't think sorting by image made sense.

Added comments in two places where changes can be made, theoretically in a Settings page if a UI were to be added in the future. One for column placement (default is 2nd), other for header title (default is Badge).
