### PR TITLE
Only show Achievements if certain plugins are active

### DIFF
--- a/achievements.php
+++ b/achievements.php
@@ -74,7 +74,7 @@ final class DPA_Achievements_Loader {
 	/**
 	 * @var array Overloads get_option()
 	 */
-	public $options      = array(); 
+	public $options      = array();
 
 	/**
 	 * @var array Overloads get_user_meta()
@@ -191,9 +191,9 @@ final class DPA_Achievements_Loader {
 		// Paths - languages
 		$this->lang_dir = apply_filters( 'dpa_lang_dir', trailingslashit( $this->plugin_dir . 'languages' ) );
 
-		// Includes 
-		$this->includes_dir = apply_filters( 'dpa_includes_dir', trailingslashit( $this->plugin_dir . 'includes' ) ); 
-		$this->includes_url = apply_filters( 'dpa_includes_url', trailingslashit( $this->plugin_url . 'includes' ) ); 
+		// Includes
+		$this->includes_dir = apply_filters( 'dpa_includes_dir', trailingslashit( $this->plugin_dir . 'includes' ) );
+		$this->includes_url = apply_filters( 'dpa_includes_url', trailingslashit( $this->plugin_url . 'includes' ) );
 
 		// Post type/endpoint/taxonomy identifiers
 		$this->achievement_post_type          = apply_filters( 'dpa_achievement_post_type',          'achievement'  );
@@ -219,7 +219,7 @@ final class DPA_Achievements_Loader {
 		$this->domain     = 'dpa';            // Unique identifier for retrieving translated strings
 		$this->errors     = new WP_Error();   // Errors
 		$this->extensions = new stdClass();   // Other plugins add data here
-		
+
 		// Deep integration with other plugins
 		$this->integrate_into_buddypress = false;  // Use BuddyPress profiles for screens like "my achievements"
 
@@ -275,16 +275,13 @@ final class DPA_Achievements_Loader {
 		/**
 		 * Plugin extensions
 		 */
-
-		//Not sure if there is a better way to include this Paul? Without it you'll get a "Call to undefined function is_plugin_active()" error
-		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
-		if ( is_plugin_active( 'bbpress/bbpress.php' ) ) require( $this->includes_dir . 'extensions/bbpress.php'      );
-		if ( is_plugin_active( 'buddypress/bp-loader.php' ) ) require( $this->includes_dir . 'extensions/buddypress.php'   );
-		if ( is_plugin_active( 'buddystream/buddystream.php' ) ) require( $this->includes_dir . 'extensions/buddystream.php'  );
-		if ( is_plugin_active( 'invite-anyone/invite-anyone.php' ) ) require( $this->includes_dir . 'extensions/inviteanyone.php' );
-		if ( is_plugin_active( 'buddypress-courseware/courseware.php' ) ) require( $this->includes_dir . 'extensions/scholarpress.php' );
+		require( $this->includes_dir . 'extensions/bbpress.php'      );
+		require( $this->includes_dir . 'extensions/buddypress.php'   );
+		require( $this->includes_dir . 'extensions/buddystream.php'  );
+		require( $this->includes_dir . 'extensions/inviteanyone.php' );
+		require( $this->includes_dir . 'extensions/scholarpress.php' );
 		require( $this->includes_dir . 'extensions/wordpress.php'    );
-		if ( is_plugin_active( 'wp-e-commerce/wp-shopping-cart.php' ) ) require( $this->includes_dir . 'extensions/wpecommerce.php'  );
+		require( $this->includes_dir . 'extensions/wpecommerce.php'  );
 
 		require( $this->includes_dir . 'buddypress/functions.php'    );
 

--- a/achievements.php
+++ b/achievements.php
@@ -275,6 +275,8 @@ final class DPA_Achievements_Loader {
 		/**
 		 * Plugin extensions
 		 */
+		//We need this so that is_active_plugin is registered when we check for active plugins
+		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 		require( $this->includes_dir . 'extensions/bbpress.php'      );
 		require( $this->includes_dir . 'extensions/buddypress.php'   );
 		require( $this->includes_dir . 'extensions/buddystream.php'  );

--- a/achievements.php
+++ b/achievements.php
@@ -275,13 +275,16 @@ final class DPA_Achievements_Loader {
 		/**
 		 * Plugin extensions
 		 */
-		require( $this->includes_dir . 'extensions/bbpress.php'      );
-		require( $this->includes_dir . 'extensions/buddypress.php'   );
-		require( $this->includes_dir . 'extensions/buddystream.php'  );
-		require( $this->includes_dir . 'extensions/inviteanyone.php' );
-		require( $this->includes_dir . 'extensions/scholarpress.php' );
+
+		//Not sure if there is a better way to include this Paul? Without it you'll get a "Call to undefined function is_plugin_active()" error
+		include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+		if ( is_plugin_active( 'bbpress/bbpress.php' ) ) require( $this->includes_dir . 'extensions/bbpress.php'      );
+		if ( is_plugin_active( 'buddypress/bp-loader.php' ) ) require( $this->includes_dir . 'extensions/buddypress.php'   );
+		if ( is_plugin_active( 'buddystream/buddystream.php' ) ) require( $this->includes_dir . 'extensions/buddystream.php'  );
+		if ( is_plugin_active( 'invite-anyone/invite-anyone.php' ) ) require( $this->includes_dir . 'extensions/inviteanyone.php' );
+		if ( is_plugin_active( 'buddypress-courseware/courseware.php' ) ) require( $this->includes_dir . 'extensions/scholarpress.php' );
 		require( $this->includes_dir . 'extensions/wordpress.php'    );
-		require( $this->includes_dir . 'extensions/wpecommerce.php'  );
+		if ( is_plugin_active( 'wp-e-commerce/wp-shopping-cart.php' ) ) require( $this->includes_dir . 'extensions/wpecommerce.php'  );
 
 		require( $this->includes_dir . 'buddypress/functions.php'    );
 

--- a/includes/extensions/bbpress.php
+++ b/includes/extensions/bbpress.php
@@ -38,7 +38,7 @@ class DPA_bbPress_Forum_Extension extends DPA_CPT_Extension {
 	 * @since Achievements (3.0)
 	 */
 	public function __construct() {
-		if ( is_plugin_active( 'bbpress/bbpress.php' ) || ( 'achievements-plugins' == $_GET['page'] )) {
+		if ( is_plugin_active( 'bbpress/bbpress.php' ) || ( is_admin() && isset( $_GET['page'] ) && ( 'achievements-plugins' == $_GET['page'] ) ) ) {
 			$this->actions = array(
 				// Forum
 				'bbp_deleted_forum'   => __( 'A forum is permanently deleted by the user', 'dpa' ),

--- a/includes/extensions/bbpress.php
+++ b/includes/extensions/bbpress.php
@@ -10,7 +10,6 @@
 
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;
-include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
 /**
  * Extends Achievements to support actions from bbPress

--- a/includes/extensions/bbpress.php
+++ b/includes/extensions/bbpress.php
@@ -10,6 +10,7 @@
 
 // Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) exit;
+include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
 
 /**
  * Extends Achievements to support actions from bbPress
@@ -17,8 +18,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  * @since Achievements (3.0)
  */
 function dpa_init_bbpress_extension() {
-	achievements()->extensions->bbpress = new DPA_bbPress_Forum_Extension;
 
+	achievements()->extensions->bbpress = new DPA_bbPress_Forum_Extension;
 	// Tell the world that the bbPress extension is ready
 	do_action( 'dpa_init_bbpress_extension' );
 }
@@ -38,35 +39,36 @@ class DPA_bbPress_Forum_Extension extends DPA_CPT_Extension {
 	 * @since Achievements (3.0)
 	 */
 	public function __construct() {
-		$this->actions = array(
-			// Forum
-			'bbp_deleted_forum'   => __( 'A forum is permanently deleted by the user', 'dpa' ),
-			'bbp_edit_forum'      => __( "A forum&#8217;s settings are changed by the user", 'dpa' ),
-			'bbp_new_forum'       => __( 'The user creates a new forum', 'dpa' ),
-			'bbp_trashed_forum'   => __( 'The user puts a forum into the trash', 'dpa' ),
-			'bbp_untrashed_forum' => __( 'The user restores a forum from the trash', 'dpa' ),
+		if ( is_plugin_active( 'bbpress/bbpress.php' ) || ( 'achievements-plugins' == $_GET['page'] )) {
+			$this->actions = array(
+				// Forum
+				'bbp_deleted_forum'   => __( 'A forum is permanently deleted by the user', 'dpa' ),
+				'bbp_edit_forum'      => __( "A forum&#8217;s settings are changed by the user", 'dpa' ),
+				'bbp_new_forum'       => __( 'The user creates a new forum', 'dpa' ),
+				'bbp_trashed_forum'   => __( 'The user puts a forum into the trash', 'dpa' ),
+				'bbp_untrashed_forum' => __( 'The user restores a forum from the trash', 'dpa' ),
 
-			// Topic management
-			'bbp_closed_topic'     => __( 'The user closes a topic.', 'dpa' ),
-			'bbp_merged_topic'     => __( 'Separate topics are merged together by a user', 'dpa' ),
-			'bbp_opened_topic'     => __( 'The user opens a topic for new replies', 'dpa' ),
-			'bbp_post_split_topic' => __( 'An existing topic is split into seperate threads by a user', 'dpa' ),
+				// Topic management
+				'bbp_closed_topic'     => __( 'The user closes a topic.', 'dpa' ),
+				'bbp_merged_topic'     => __( 'Separate topics are merged together by a user', 'dpa' ),
+				'bbp_opened_topic'     => __( 'The user opens a topic for new replies', 'dpa' ),
+				'bbp_post_split_topic' => __( 'An existing topic is split into seperate threads by a user', 'dpa' ),
 
-			// Topic
-			'bbp_deleted_topic'              => __( 'The user permanently deletes a topic', 'dpa' ),
-			'bbp_sticked_topic'              => __( 'The user marks a topic as a sticky', 'dpa' ),
-			'bbp_trashed_topic'              => __( 'The user trashes a topic', 'dpa' ),
-			'bbp_unsticked_topic'            => __( 'The user unstickies a topic', 'dpa' ),
-			'bbp_untrashed_topic'            => __( 'The user restores a topic from the trash', 'dpa' ),
-			'bbpress_topic_draft_to_publish' => __( 'The user creates a new topic.', 'dpa' ),
+				// Topic
+				'bbp_deleted_topic'              => __( 'The user permanently deletes a topic', 'dpa' ),
+				'bbp_sticked_topic'              => __( 'The user marks a topic as a sticky', 'dpa' ),
+				'bbp_trashed_topic'              => __( 'The user trashes a topic', 'dpa' ),
+				'bbp_unsticked_topic'            => __( 'The user unstickies a topic', 'dpa' ),
+				'bbp_untrashed_topic'            => __( 'The user restores a topic from the trash', 'dpa' ),
+				'bbpress_topic_draft_to_publish' => __( 'The user creates a new topic.', 'dpa' ),
 
-			// Reply
-			'bbp_deleted_reply'              => __( 'The user permanently deletes a reply', 'dpa' ),
-			'bbp_trashed_reply'              => __( 'The user trashes a reply', 'dpa' ),
-			'bbp_untrashed_reply'            => __( 'The user restores a reply from the trash', 'dpa' ),
-			'bbpress_reply_draft_to_publish' => __( 'The user replies to a topic.', 'dpa' ),
-		);
-
+				// Reply
+				'bbp_deleted_reply'              => __( 'The user permanently deletes a reply', 'dpa' ),
+				'bbp_trashed_reply'              => __( 'The user trashes a reply', 'dpa' ),
+				'bbp_untrashed_reply'            => __( 'The user restores a reply from the trash', 'dpa' ),
+				'bbpress_reply_draft_to_publish' => __( 'The user replies to a topic.', 'dpa' ),
+			);
+		}
 		$this->contributors = array(
 			array(
 				'name'         => 'Matt',

--- a/includes/extensions/buddypress.php
+++ b/includes/extensions/buddypress.php
@@ -39,7 +39,7 @@ class DPA_BuddyPress_Extension extends DPA_Extension {
 	 * @since Achievements (3.0)
 	 */
 	public function __construct() {
-		if ( is_plugin_active( 'buddypress/bp-loader.php' ) || ( 'achievements-plugins' == $_GET['page'] )) {
+		if ( is_plugin_active( 'buddypress/bp-loader.php' ) || ( is_admin() && isset( $_GET['page'] ) && ( 'achievements-plugins' == $_GET['page'] ) ) ) {
 			$this->actions = array(
 				'bp_activity_add_user_favorite'    => __( 'The user marks an item in an activity stream as a favourite.', 'dpa' ),
 				'bp_activity_comment_posted'       => __( 'The user replies to an item in an activity stream.', 'dpa' ),

--- a/includes/extensions/buddypress.php
+++ b/includes/extensions/buddypress.php
@@ -39,32 +39,34 @@ class DPA_BuddyPress_Extension extends DPA_Extension {
 	 * @since Achievements (3.0)
 	 */
 	public function __construct() {
-		$this->actions = array(
-			'bp_activity_add_user_favorite'    => __( 'The user marks an item in an activity stream as a favourite.', 'dpa' ),
-			'bp_activity_comment_posted'       => __( 'The user replies to an item in an activity stream.', 'dpa' ),
-			'bp_activity_posted_update'        => __( 'The user writes an activity update message.', 'dpa' ),
-			'bp_activity_remove_user_favorite' => __( 'The user un-favourites an item in their activity stream.', 'dpa' ),
-			'bp_core_activated_user'           => __( 'A new user activates their account on your website.', 'dpa' ),
-			'bp_groups_posted_update'          => __( "The user writes a message in a group&#8217;s activity stream.", 'dpa' ),
-			'friends_friendship_accepted'      => __( 'The user accepts a friendship request from someone.', 'dpa' ),
-			'friends_friendship_deleted'       => __( 'The user cancels a friendship.', 'dpa' ),
-			'friends_friendship_rejected'      => __( 'The user rejects a friendship request from someone.', 'dpa' ),
-			'friends_friendship_requested'     => __( 'The user sends a friendship request to someone.', 'dpa' ),
-			'groups_banned_member'             => __( 'The user bans a member from a group.', 'dpa' ),
-			'groups_group_create_complete'     => __( 'The user creates a group.', 'dpa' ),
-			'groups_delete_group'              => __( 'The user deletes a group.', 'dpa' ),
-			'groups_demoted_member'            => __( 'The user demotes a group member from moderator or administrator status.', 'dpa' ),
-			'groups_invite_user'               => __( 'The user invites someone to join a group.', 'dpa' ),
-			'groups_join_group'                => __( 'The user joins a group.', 'dpa' ),
-			'groups_leave_group'               => __( 'The user leaves a group.', 'dpa' ),
-			'groups_promote_member'            => __( 'The user is promoted to a moderator or an administrator in a group.', 'dpa' ),
-			'groups_promoted_member'           => __( 'The user promotes a group member to moderator or administrator status.', 'dpa' ),
-			'groups_unbanned_member'           => __( 'The user unbans a member from a group.', 'dpa' ),
-			'messages_delete_thread'           => __( 'The user deletes a private message.', 'dpa' ),
-			'messages_message_sent'            => __( 'The user sends a new private message or replies to an existing one.', 'dpa' ),
-			'xprofile_avatar_uploaded'         => __( "The user changes their profile&#8217;s avatar.", 'dpa' ),
-			'xprofile_updated_profile'         => __( 'The user updates their profile information.', 'dpa' ),
-		);
+		if ( is_plugin_active( 'buddypress/bp-loader.php' ) || ( 'achievements-plugins' == $_GET['page'] )) {
+			$this->actions = array(
+				'bp_activity_add_user_favorite'    => __( 'The user marks an item in an activity stream as a favourite.', 'dpa' ),
+				'bp_activity_comment_posted'       => __( 'The user replies to an item in an activity stream.', 'dpa' ),
+				'bp_activity_posted_update'        => __( 'The user writes an activity update message.', 'dpa' ),
+				'bp_activity_remove_user_favorite' => __( 'The user un-favourites an item in their activity stream.', 'dpa' ),
+				'bp_core_activated_user'           => __( 'A new user activates their account on your website.', 'dpa' ),
+				'bp_groups_posted_update'          => __( "The user writes a message in a group&#8217;s activity stream.", 'dpa' ),
+				'friends_friendship_accepted'      => __( 'The user accepts a friendship request from someone.', 'dpa' ),
+				'friends_friendship_deleted'       => __( 'The user cancels a friendship.', 'dpa' ),
+				'friends_friendship_rejected'      => __( 'The user rejects a friendship request from someone.', 'dpa' ),
+				'friends_friendship_requested'     => __( 'The user sends a friendship request to someone.', 'dpa' ),
+				'groups_banned_member'             => __( 'The user bans a member from a group.', 'dpa' ),
+				'groups_group_create_complete'     => __( 'The user creates a group.', 'dpa' ),
+				'groups_delete_group'              => __( 'The user deletes a group.', 'dpa' ),
+				'groups_demoted_member'            => __( 'The user demotes a group member from moderator or administrator status.', 'dpa' ),
+				'groups_invite_user'               => __( 'The user invites someone to join a group.', 'dpa' ),
+				'groups_join_group'                => __( 'The user joins a group.', 'dpa' ),
+				'groups_leave_group'               => __( 'The user leaves a group.', 'dpa' ),
+				'groups_promote_member'            => __( 'The user is promoted to a moderator or an administrator in a group.', 'dpa' ),
+				'groups_promoted_member'           => __( 'The user promotes a group member to moderator or administrator status.', 'dpa' ),
+				'groups_unbanned_member'           => __( 'The user unbans a member from a group.', 'dpa' ),
+				'messages_delete_thread'           => __( 'The user deletes a private message.', 'dpa' ),
+				'messages_message_sent'            => __( 'The user sends a new private message or replies to an existing one.', 'dpa' ),
+				'xprofile_avatar_uploaded'         => __( "The user changes their profile&#8217;s avatar.", 'dpa' ),
+				'xprofile_updated_profile'         => __( 'The user updates their profile information.', 'dpa' ),
+			);
+		}
 
 		$this->contributors = array(
 			array(

--- a/includes/extensions/buddystream.php
+++ b/includes/extensions/buddystream.php
@@ -38,13 +38,15 @@ class DPA_Buddy_Stream_Extension extends DPA_Extension {
 	 * @since Achievements (3.0)
 	 */
 	public function __construct() {
-		$this->actions = array(
-			'buddystream_facebook_activated' => __( 'The user connects their Facebook account to BuddyStream.', 'dpa' ),
-			'buddystream_flickr_activated'   => __( 'The user connects their Flickr account to BuddyStream.', 'dpa' ),
-			'buddystream_lastfm_activated'   => __( 'The user connects their Last.fm account to BuddyStream.', 'dpa' ),
-			'buddystream_twitter_activated'  => __( 'The user connects their Twitter account to BuddyStream.', 'dpa' ),
-			'buddystream_youtube_activated'  => __( 'The user connects their YouTube account to BuddyStream.', 'dpa' ),
-		);
+		if ( is_plugin_active( 'buddystream/buddystream.php' ) || ( 'achievements-plugins' == $_GET['page'] )) {
+			$this->actions = array(
+				'buddystream_facebook_activated' => __( 'The user connects their Facebook account to BuddyStream.', 'dpa' ),
+				'buddystream_flickr_activated'   => __( 'The user connects their Flickr account to BuddyStream.', 'dpa' ),
+				'buddystream_lastfm_activated'   => __( 'The user connects their Last.fm account to BuddyStream.', 'dpa' ),
+				'buddystream_twitter_activated'  => __( 'The user connects their Twitter account to BuddyStream.', 'dpa' ),
+				'buddystream_youtube_activated'  => __( 'The user connects their YouTube account to BuddyStream.', 'dpa' ),
+			);
+		}
 
 		$this->contributors = array(
 			array(

--- a/includes/extensions/buddystream.php
+++ b/includes/extensions/buddystream.php
@@ -38,7 +38,7 @@ class DPA_Buddy_Stream_Extension extends DPA_Extension {
 	 * @since Achievements (3.0)
 	 */
 	public function __construct() {
-		if ( is_plugin_active( 'buddystream/buddystream.php' ) || ( 'achievements-plugins' == $_GET['page'] )) {
+		if ( is_plugin_active( 'buddystream/buddystream.php' ) || ( is_admin() && isset( $_GET['page'] ) && ( 'achievements-plugins' == $_GET['page'] ) ) ) {
 			$this->actions = array(
 				'buddystream_facebook_activated' => __( 'The user connects their Facebook account to BuddyStream.', 'dpa' ),
 				'buddystream_flickr_activated'   => __( 'The user connects their Flickr account to BuddyStream.', 'dpa' ),

--- a/includes/extensions/inviteanyone.php
+++ b/includes/extensions/inviteanyone.php
@@ -38,10 +38,12 @@ class DPA_Invite_Anyone_Extension extends DPA_Extension {
 	 * @since Achievements (3.0)
 	 */
 	public function __construct() {
-		$this->actions = array(
-			'accepted_email_invite' => __( 'A new user activates their account.', 'dpa' ),
-			'sent_email_invite'     => __( 'The user invites someone else to join the site.', 'dpa' ),
-		);
+		if ( is_plugin_active( 'invite-anyone/invite-anyone.php' ) || ( 'achievements-plugins' == $_GET['page'] )) {
+			$this->actions = array(
+				'accepted_email_invite' => __( 'A new user activates their account.', 'dpa' ),
+				'sent_email_invite'     => __( 'The user invites someone else to join the site.', 'dpa' ),
+			);
+		}
 
 		$this->contributors = array(
 			array(

--- a/includes/extensions/inviteanyone.php
+++ b/includes/extensions/inviteanyone.php
@@ -38,7 +38,7 @@ class DPA_Invite_Anyone_Extension extends DPA_Extension {
 	 * @since Achievements (3.0)
 	 */
 	public function __construct() {
-		if ( is_plugin_active( 'invite-anyone/invite-anyone.php' ) || ( 'achievements-plugins' == $_GET['page'] )) {
+		if ( is_plugin_active( 'invite-anyone/invite-anyone.php' ) || ( is_admin() && isset( $_GET['page'] ) && ( 'achievements-plugins' == $_GET['page'] ) ) ) {
 			$this->actions = array(
 				'accepted_email_invite' => __( 'A new user activates their account.', 'dpa' ),
 				'sent_email_invite'     => __( 'The user invites someone else to join the site.', 'dpa' ),

--- a/includes/extensions/scholarpress.php
+++ b/includes/extensions/scholarpress.php
@@ -38,15 +38,17 @@ class DPA_BuddyPress_Courseware_Extension extends DPA_Extension {
 	 * @since Achievements (3.0)
 	 */
 	public function __construct() {
-		$this->actions = array(
-			'courseware_new_teacher_added'   => __( 'The user is added as a teacher', 'dpa' ),
-			'courseware_grade_added'         => __( 'A grade is given to the user', 'dpa' ),
-			'courseware_grade_updated'       => __( "A user&rsquo;s grade is updated", 'dpa' ),
-			'courseware_assignment_added'    => __( 'The user creates a new assignment', 'dpa' ),
-			'courseware_lecture_added'       => __( 'The user creates a new lecture', 'dpa' ),
-			'courseware_response_added'      => __( 'The user adds a response to an assignment', 'dpa' ),
-			'courseware_schedule_activity'   => __( 'The user creates a new schedule', 'dpa' ),
-		);
+		if ( is_plugin_active( 'buddypress-courseware/courseware.php' ) || ( 'achievements-plugins' == $_GET['page'] )) {
+			$this->actions = array(
+				'courseware_new_teacher_added'   => __( 'The user is added as a teacher', 'dpa' ),
+				'courseware_grade_added'         => __( 'A grade is given to the user', 'dpa' ),
+				'courseware_grade_updated'       => __( "A user&rsquo;s grade is updated", 'dpa' ),
+				'courseware_assignment_added'    => __( 'The user creates a new assignment', 'dpa' ),
+				'courseware_lecture_added'       => __( 'The user creates a new lecture', 'dpa' ),
+				'courseware_response_added'      => __( 'The user adds a response to an assignment', 'dpa' ),
+				'courseware_schedule_activity'   => __( 'The user creates a new schedule', 'dpa' ),
+			);
+		}
 
 		$this->contributors = array(
 			array(

--- a/includes/extensions/scholarpress.php
+++ b/includes/extensions/scholarpress.php
@@ -38,7 +38,7 @@ class DPA_BuddyPress_Courseware_Extension extends DPA_Extension {
 	 * @since Achievements (3.0)
 	 */
 	public function __construct() {
-		if ( is_plugin_active( 'buddypress-courseware/courseware.php' ) || ( 'achievements-plugins' == $_GET['page'] )) {
+		if ( is_plugin_active( 'buddypress-courseware/courseware.php' ) || ( is_admin() && isset( $_GET['page'] ) && ( 'achievements-plugins' == $_GET['page'] ) ) ) {
 			$this->actions = array(
 				'courseware_new_teacher_added'   => __( 'The user is added as a teacher', 'dpa' ),
 				'courseware_grade_added'         => __( 'A grade is given to the user', 'dpa' ),

--- a/includes/extensions/wpecommerce.php
+++ b/includes/extensions/wpecommerce.php
@@ -38,7 +38,7 @@ class DPA_WP_e_Commerce_Extension extends DPA_Extension {
 	 * @since Achievements (3.0)
 	 */
 	public function __construct() {
-		if ( is_plugin_active( 'wp-e-commerce/wp-shopping-cart.php' ) || ( 'achievements-plugins' == $_GET['page'] )) {
+		if ( is_plugin_active( 'wp-e-commerce/wp-shopping-cart.php' ) || ( is_admin() && isset( $_GET['page'] ) && ( 'achievements-plugins' == $_GET['page'] ) ) ) {
 			$this->actions = array(
 				'wpsc_activate_subscription' => __( 'The user sets up a PayPal Subscription', 'dpa' ),
 				'wpsc_payment_successful'    => __( 'The user completes checkout', 'dpa' ),

--- a/includes/extensions/wpecommerce.php
+++ b/includes/extensions/wpecommerce.php
@@ -38,10 +38,12 @@ class DPA_WP_e_Commerce_Extension extends DPA_Extension {
 	 * @since Achievements (3.0)
 	 */
 	public function __construct() {
-		$this->actions = array(
-			'wpsc_activate_subscription' => __( 'The user sets up a PayPal Subscription', 'dpa' ),
-			'wpsc_payment_successful'    => __( 'The user completes checkout', 'dpa' ),
-		);
+		if ( is_plugin_active( 'wp-e-commerce/wp-shopping-cart.php' ) || ( 'achievements-plugins' == $_GET['page'] )) {
+			$this->actions = array(
+				'wpsc_activate_subscription' => __( 'The user sets up a PayPal Subscription', 'dpa' ),
+				'wpsc_payment_successful'    => __( 'The user completes checkout', 'dpa' ),
+			);
+		}
 
 		$this->contributors = array(
 			array(


### PR DESCRIPTION
Hey Paul,

Firstly, great work on Achievements. I'm amazed by how much work you've done in 3.0+ :)

I'm currently doing some prototyping for a potential job and thought that it from a UI point of view it would make more sense to only show achievements for a plugin if it's activated.

In my first pass I checked if plugins were active in the "Plugin extensions" section of achievements.php but then I realised that if I did that it broke the Supported Plugins section of Achievements.

This is my second pass which fixes that problem by tackling it in a different way. It looks like there is some whitespace issues in the patch...I blame PhpStorm & Windows for that :)

Hopefully you can sneak this in 3.3 if you haven't shipped it yet :)

I've attached some screenshots to show my testing as well. Hopefully we'll get this job too and I'll be able to add loads more patches!

![BuddyPress and WordPress are active](https://f.cloud.github.com/assets/1377956/470572/8b716880-b6fc-11e2-8d64-979e7e091b78.png)
![Supported Plugins Page](https://f.cloud.github.com/assets/1377956/470573/8b7253f8-b6fc-11e2-8f1b-a20a88f9e8d1.png)
![Supported Features Page Without bbPress Activated](https://f.cloud.github.com/assets/1377956/470574/8ba81010-b6fc-11e2-9459-a94ff14a31af.png)
![Supported Features Page When bbPress Isn't Installed](https://f.cloud.github.com/assets/1377956/470575/8ba8ff16-b6fc-11e2-8215-abbe77d8e37f.png)

I hope you're having fun working in VIP too :+1: 

Cheers!
