### PR TITLE
Clear achievements after displaying notifications

### DIFF
--- a/includes/users/notifications.php
+++ b/includes/users/notifications.php
@@ -53,19 +53,16 @@ function dpa_print_notifications() {
 	$achievements  = array();
 	$notifications = dpa_get_user_notifications();
 
-	// If we're viewing an achievement, clear the notification
-	if ( ! empty( $notifications ) && dpa_is_single_achievement() && isset( $notifications[get_the_ID()] ) ) {
-		unset( $notifications[get_the_ID()] );
-
-		// Save the user's notifications
-		dpa_update_user_notifications( $notifications );
-	}
-
 	if ( empty( $notifications ) )
 		return;
 
 	// Display notifications
 	echo achievements()->shortcodes->display_feedback_achievement_unlocked();
+
+	// Clear the notifications
+	foreach ( $notifications as $id => $value ) {
+		dpa_clear_notification( $id );
+	}
 }
 
 /**


### PR DESCRIPTION
Rather than clear these when viewing the achievement page, clear them after the notification has been shown.

Also, use the standard clear notification function.

---

Apologies for the newline at the end of the file, GitHub's editor appears to have added that. If you'd like, I can repush this.

Alternative solution: implement an Ajax handler for when the background is clicked, or add an action so a plugin can do this.

This fixes the following .org support requests:
- [Achievement notification always shows up](http://wordpress.org/support/topic/achievement-notification-always-shows-up)
- [Achievement box won't go away...](http://wordpress.org/support/topic/achievement-box-wont-go-away?replies=2)
- [Popup Bug Report](http://wordpress.org/support/topic/bug-report-13)
