### PR TITLE
Add support for hidden achievements

### DIFF
--- a/includes/core/functions.php
+++ b/includes/core/functions.php
@@ -212,7 +212,7 @@ function dpa_handle_event() {
 		'ach_populate_progress' => $user_id,     // Fetch Progress posts for this user ID
 		'no_found_rows'         => true,         // Disable SQL_CALC_FOUND_ROWS
 		'nopaging'              => true,         // No pagination
-		'post_status'           => 'publish',    // We only want active achievements
+		'post_status'           => 'any',        // We only want published/private achievements, but need to compensate (see below)
 		'posts_per_page'        => -1,           // No pagination
 		's'                     => '',           // Stop sneaky people running searches on this query
 	);
@@ -226,6 +226,12 @@ function dpa_handle_event() {
 
 		while ( dpa_achievements() ) {
 			dpa_the_achievement();
+
+			// Check that the post status is published or privately published
+			// We need to check this here to work around WP_Query not
+			// constructing the query correctly with private
+			if ( ! in_array( $GLOBALS['post']->post_status, array( 'publish', 'private' ) ) )
+				continue;
 
 			// Let other plugins do things before we maybe_unlock_achievement
 			do_action( 'dpa_handle_event', $event_name, $func_args, $user_id, $args );

--- a/templates/achievements/achievements/feedback-achievement-unlocked.php
+++ b/templates/achievements/achievements/feedback-achievement-unlocked.php
@@ -30,6 +30,7 @@ function dpa_feedback_achievement_unlock_wrapper() {
 	$notifications = dpa_get_achievements( array(
 		'numberposts' => 1,
 		'post__in'    => array_keys( $post_ids ),
+		'post_status' => 'any',
 	) );
 
 	// It's possible for the usermeta to reference posts that have been deleted or are in the trash, so check here.


### PR DESCRIPTION
This uses the Privately Published status to hide the achievements from
the UI, but allows them to be unlocked and displayed in notifications.

Fixes #34
