### PR TITLE
Fixes dpa_is_single_user_achievements for custom endpoints

### DIFF
--- a/includes/common/template.php
+++ b/includes/common/template.php
@@ -120,7 +120,7 @@ function dpa_is_single_user_achievements() {
 
 	// Using BuddyPress user profiles
 	if ( dpa_integrate_into_buddypress() ) {
-		$retval = bp_is_user() && bp_is_current_component( 'achievements' ) && bp_is_current_action( 'all' );
+		$retval = bp_is_user() && bp_is_current_component( dpa_get_authors_endpoint() ) && bp_is_current_action( 'all' );
 
 	// Using WordPress' author page and the 'achievements' endpoint
 	} else {


### PR DESCRIPTION
Hey Paul,

I'm back on deck and into our achievements project again. I just stumbled across a bug where my achievements weren't showing in BuddyPress. We're using a custom endpoint called 'challenges'. This fixes the templates for custom endpoints. Cheers!

P.S. I'll try and get some sample code to you regarding the leaderboard tomorrow too :grin: 
