### PR TITLE
Remove the dev folders in the build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,13 +4,15 @@ module.exports = function(grunt) {
 	var SOURCE_DIR = 'src/';
 	var BUILD_DIR = 'build/';
 
-	// Load tasks. 
+	// Load tasks.
 	require('matchdep').filterDev('grunt-*').forEach( grunt.loadNpmTasks );
 
 	// Project configuration.
 	grunt.initConfig({
 		clean: {
 			all: [BUILD_DIR],
+			build: [BUILD_DIR + 'templates/achievements/css/dev/',
+							BUILD_DIR + 'includes/admin/css/dev/'],
 			dynamic: {
 				cwd: BUILD_DIR,
 				dot: true,
@@ -82,7 +84,7 @@ module.exports = function(grunt) {
 	});
 
 	// Register tasks.
-	grunt.registerTask('build', ['clean:all', 'copy:all', 'less:core', 'cssmin:core', 'uglify:core']);
+	grunt.registerTask('build', ['copy:all', 'less:core', 'cssmin:core', 'uglify:core', 'clean:build']);
 
 	// Default task.
 	grunt.registerTask('default', ['build']);


### PR DESCRIPTION
Hey Paul,

Firstly, massive props for shipping 3.4 :+1: Great work as always from you!

I saw you popping in Grunt when I woke up this morning and was keen to see where you were at with it. This patch will fix up point number 2 here: https://github.com/paulgibbs/achievements/issues/116

I'm also curious to know how you've got the new folder structure setup on your computer. Have you got a symlink to the src folder in plugins/achievements?

It looks like you could use some watches in Grunt for this as well so I might have a play around now for you to see if I can come up with anything. I've only been using Grunt for about 14 days so I'm a noob too. I've been playing around with a Sennza version of 10up's grunt plugin: https://github.com/sennza/grunt-wp-plugin :grin: 
